### PR TITLE
Explicitly import versions for all Gnome related libraries.

### DIFF
--- a/ulauncher/api/server/DeferredResultRenderer.py
+++ b/ulauncher/api/server/DeferredResultRenderer.py
@@ -1,6 +1,9 @@
 import logging
 from functools import partial
 from threading import Timer
+import gi
+gi.require_version('GLib', '2.0')
+# pylint: disable=wrong-import-position
 from gi.repository import GLib
 
 from ulauncher.api.shared.action.DoNothingAction import DoNothingAction

--- a/ulauncher/api/shared/action/CopyToClipboardAction.py
+++ b/ulauncher/api/shared/action/CopyToClipboardAction.py
@@ -1,6 +1,7 @@
 import gi
 # pylint: disable=wrong-import-position
 gi.require_version('Gtk', '3.0')
+gi.require_version('Gdk', '3.0')
 from gi.repository import Gtk, Gdk
 
 from ulauncher.api.shared.action.BaseAction import BaseAction

--- a/ulauncher/api/shared/action/RenderResultListAction.py
+++ b/ulauncher/api/shared/action/RenderResultListAction.py
@@ -1,3 +1,6 @@
+import gi
+gi.require_version('GLib', '2.0')
+# pylint: disable=wrong-import-position
 from gi.repository import GLib
 from ulauncher.api.shared.action.BaseAction import BaseAction
 

--- a/ulauncher/api/shared/action/SetUserQueryAction.py
+++ b/ulauncher/api/shared/action/SetUserQueryAction.py
@@ -1,4 +1,7 @@
 from time import sleep
+import gi
+gi.require_version('GLib', '2.0')
+# pylint: disable=wrong-import-position
 from gi.repository import GLib
 
 from ulauncher.api.shared.action.BaseAction import BaseAction

--- a/ulauncher/search/file_browser/FileBrowserMode.py
+++ b/ulauncher/search/file_browser/FileBrowserMode.py
@@ -1,5 +1,8 @@
 import os
 from typing import List, Union
+import gi
+gi.require_version('Gdk', '3.0')
+# pylint: disable=wrong-import-position
 from gi.repository import Gdk
 
 from ulauncher.api.shared.action.BaseAction import BaseAction

--- a/ulauncher/ui/AppIndicator.py
+++ b/ulauncher/ui/AppIndicator.py
@@ -1,6 +1,7 @@
 import logging
 
 import gi
+gi.require_version('Gtk', '3.0')
 gi.require_version('AppIndicator3', '0.1')
 
 # pylint: disable=wrong-import-position

--- a/ulauncher/ui/ResultItemWidget.py
+++ b/ulauncher/ui/ResultItemWidget.py
@@ -1,5 +1,9 @@
 import logging
 from typing import Any
+import gi
+gi.require_version('Gtk', '3.0')
+gi.require_version('Gdk', '3.0')
+# pylint: disable=wrong-import-position
 from gi.repository import Gtk, Gdk
 
 from ulauncher.utils.Theme import Theme

--- a/ulauncher/ui/windows/Builder.py
+++ b/ulauncher/ui/windows/Builder.py
@@ -8,6 +8,7 @@ import logging
 from xml.etree.cElementTree import ElementTree
 
 import gi
+gi.require_version('GObject', '2.0')
 gi.require_version('Gtk', '3.0')
 # pylint: disable=wrong-import-position, wrong-import-order
 from gi.repository import GObject, Gtk

--- a/ulauncher/ui/windows/HotkeyDialog.py
+++ b/ulauncher/ui/windows/HotkeyDialog.py
@@ -1,4 +1,9 @@
 import logging
+import gi
+gi.require_version('GObject', '2.0')
+gi.require_version('Gtk', '3.0')
+gi.require_version('Gdk', '3.0')
+# pylint: disable=wrong-import-position
 from gi.repository import Gtk, Gdk, GObject
 
 from ulauncher.ui.windows.Builder import Builder

--- a/ulauncher/ui/windows/PreferencesUlauncherDialog.py
+++ b/ulauncher/ui/windows/PreferencesUlauncherDialog.py
@@ -7,6 +7,9 @@ from typing import List, Optional, cast
 import traceback
 
 import gi
+gi.require_version('Gio', '2.0')
+gi.require_version('GLib', '2.0')
+gi.require_version('Gtk', '3.0')
 gi.require_version('WebKit2', '4.0')
 
 # pylint: disable=wrong-import-position,unused-argument

--- a/ulauncher/ui/windows/WindowHelper.py
+++ b/ulauncher/ui/windows/WindowHelper.py
@@ -1,3 +1,6 @@
+import gi
+gi.require_version('Gtk', '3.0')
+# pylint: disable=wrong-import-position
 from gi.repository import Gtk
 
 

--- a/ulauncher/utils/Settings.py
+++ b/ulauncher/utils/Settings.py
@@ -1,6 +1,9 @@
 import os
 import json
 from distutils.dir_util import mkpath
+import gi
+gi.require_version('GObject', '2.0')
+# pylint: disable=wrong-import-position
 from gi.repository import GObject
 
 from ulauncher.utils.decorator.singleton import singleton

--- a/ulauncher/utils/decorator/glib_idle_add.py
+++ b/ulauncher/utils/decorator/glib_idle_add.py
@@ -1,4 +1,7 @@
 from functools import wraps
+import gi
+gi.require_version('GLib', '2.0')
+# pylint: disable=wrong-import-position
 from gi.repository import GLib
 
 

--- a/ulauncher/utils/desktop/reader.py
+++ b/ulauncher/utils/desktop/reader.py
@@ -4,6 +4,9 @@ from collections import OrderedDict
 from itertools import chain
 from typing import Generator, List
 
+import gi
+gi.require_version('Gio', '2.0')
+# pylint: disable=wrong-import-position
 from gi.repository import Gio
 
 from ulauncher.utils.file_finder import find_files

--- a/ulauncher/utils/display.py
+++ b/ulauncher/utils/display.py
@@ -1,4 +1,8 @@
 import logging
+import gi
+gi.require_version('Gdk', '3.0')
+gi.require_version('GdkX11', '3.0')
+# pylint: disable=wrong-import-position
 from gi.repository import Gdk, GdkX11
 
 logger = logging.getLogger(__name__)

--- a/ulauncher/utils/image_loader.py
+++ b/ulauncher/utils/image_loader.py
@@ -3,7 +3,10 @@ import logging
 from functools import lru_cache
 
 import gi
+gi.require_version('GLib', '2.0')
 gi.require_version('Gtk', '3.0')
+gi.require_version('Gio', '2.0')
+gi.require_version('GdkPixbuf', '2.0')
 
 # pylint: disable=wrong-import-position
 from gi.repository import Gtk, Gio, GLib, GdkPixbuf

--- a/ulauncher/utils/version_cmp.py
+++ b/ulauncher/utils/version_cmp.py
@@ -1,4 +1,7 @@
 from distutils.version import StrictVersion
+import gi
+gi.require_version('Gtk', '3.0')
+# pylint: disable=wrong-import-position
 from gi.repository import Gtk
 
 


### PR DESCRIPTION
With the release of Gtk4 newer systems will default to Gtk4 instead of Gtk3.
Without explicit versioned imports this can lead to a mismatch of loaded
versions. Standardize on Gtk3 for now.

Fixes issue #703.

<!--
Thank you for submitting a PR to Ulauncher!

You can also read more about contributing in this document:
https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution
-->
### Link to related issue (if applicable)
<!--
This is not required, but for your own sake you may want to ensure before putting a lot of time on a PR, that the change is something we want to add and support. If there isn't an issue for it, you're welcome to create one.
-->

### Summary of the changes in this PR

### Checklist (see more [here](https://github.com/Ulauncher/Ulauncher/wiki/Code-Contribution))
- [ ] Use `dev` as the base branch
- [ ] Follow the [Python Code Style Guides](https://github.com/Ulauncher/Ulauncher/wiki/Python-Code-Style-Guides)
- [ ] Write unit tests for your changes when applicable
- [ ] If your changes alters the behavior or introduce new functionality, please update the documentation accordingly
- [ ] All tests are passing

### Tested environment (distro, desktop environment and their versions)
